### PR TITLE
update README to use github homepage

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,6 @@
 = osx_keychain
 
-* http://rubyforge.org/projects/seattlerb
+* https://github.com/seattlerb/osx_keychain
 
 == DESCRIPTION:
 


### PR DESCRIPTION
Removes defunct rubyforge URL and replaces it with current GitHub hosting.

Noticed after seeing the defunct rubyforge URL on @zenspider's page https://www.zenspider.com/releases/2018/03/osx_keychain-version-1-0-2-has-been-released.html